### PR TITLE
compileSdkVersion, buildToolsVersion, targetSdkVersion を30にあげる

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -6,12 +6,12 @@ apply plugin: "androidx.navigation.safeargs.kotlin"
 apply plugin: 'com.google.firebase.crashlytics'
 
 android {
-    compileSdkVersion 29
-    buildToolsVersion '29.0.2'
+    compileSdkVersion 30
+    buildToolsVersion '30.0.2'
     defaultConfig {
         applicationId "com.banbara.yaeyama.liner.checker"
         minSdkVersion 16
-        targetSdkVersion 29
+        targetSdkVersion 30
         versionCode 59
         versionName "3.7.0"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"


### PR DESCRIPTION
## やったこと
Android 11 をターゲットにするようにアプリのビルド構成を変更する

## 公式ドキュメント
- Android 11 SDK をセットアップする  |  Android デベロッパー  |  Android Developers https://developer.android.com/about/versions/11/setup-sdk?hl=ja
- Android 11 にアプリを移行する  |  Android デベロッパー  |  Android Developers https://developer.android.com/about/versions/11/migration?hl=ja
- 動作の変更点: Android 11 をターゲットとするアプリ  |  Android デベロッパー  |  Android Developers https://developer.android.com/about/versions/11/behavior-changes-11?hl=ja
  - 目を通したが、自分のアプリには影響なし