### PR TITLE
Gradle警告を消すためライブラリをアップグレード

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -17,7 +17,7 @@ android {
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables.useSupportLibrary = true
         multiDexEnabled true
-        
+
     }
     buildTypes {
         release {
@@ -45,39 +45,37 @@ android {
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
     // android
-    implementation 'androidx.multidex:multidex:2.0.0'
-    implementation 'androidx.appcompat:appcompat:1.0.0'
+    implementation 'androidx.multidex:multidex:2.0.1'
+    implementation 'androidx.appcompat:appcompat:1.2.0'
     implementation 'com.google.android.material:material:1.0.0'
-    implementation 'androidx.vectordrawable:vectordrawable:1.0.0'
+    implementation 'androidx.vectordrawable:vectordrawable:1.1.0'
     implementation 'androidx.cardview:cardview:1.0.0'
-    implementation 'androidx.browser:browser:1.2.0'
-    implementation 'androidx.constraintlayout:constraintlayout:1.1.3'
+    implementation 'androidx.browser:browser:1.3.0'
+    implementation 'androidx.constraintlayout:constraintlayout:2.0.4'
     implementation 'androidx.lifecycle:lifecycle-viewmodel-ktx:2.2.0'
     implementation 'androidx.lifecycle:lifecycle-runtime-ktx:2.2.0'
-    implementation 'androidx.navigation:navigation-fragment-ktx:2.3.2'
-    implementation 'androidx.navigation:navigation-ui-ktx:2.3.2'
     implementation 'androidx.lifecycle:lifecycle-livedata-ktx:2.2.0'
-    kapt 'androidx.databinding:databinding-compiler-common:3.6.0'
-    implementation "androidx.fragment:fragment-ktx:1.2.4"
-    def nav_version = "2.3.0-alpha06"
+    kapt 'androidx.databinding:databinding-compiler-common:4.1.2'
+    implementation "androidx.fragment:fragment-ktx:1.2.5"
+    def nav_version = "2.3.3"
     implementation "androidx.navigation:navigation-fragment-ktx:$nav_version"
     implementation "androidx.navigation:navigation-ui-ktx:$nav_version"
     implementation "androidx.navigation:navigation-runtime-ktx:$nav_version"
     implementation "androidx.navigation:navigation-ui-ktx:$nav_version"
     // google
-    implementation 'com.google.android.gms:play-services-base:16.1.0'
+    implementation 'com.google.android.gms:play-services-base:17.6.0'
     // firebase
-    implementation 'com.google.firebase:firebase-core:17.2.2'
-    implementation 'com.google.firebase:firebase-database:19.2.1'
+    implementation 'com.google.firebase:firebase-core:18.0.2'
+    implementation 'com.google.firebase:firebase-database:19.6.0'
     // crashlytics
-    implementation 'com.google.firebase:firebase-crashlytics:17.2.2'
+    implementation 'com.google.firebase:firebase-crashlytics:17.3.1'
     // Google Analytics
-    implementation 'com.google.firebase:firebase-analytics:17.6.0'
+    implementation 'com.google.firebase:firebase-analytics:18.0.2'
     // rx2firebase
     implementation 'com.github.FrangSierra:RxFirebase:1.5.6'
     // RxJava
-    implementation 'io.reactivex.rxjava2:rxjava:2.2.7'
-    implementation 'io.reactivex.rxjava2:rxandroid:2.1.0'
+    implementation 'io.reactivex.rxjava2:rxjava:2.2.10'
+    implementation 'io.reactivex.rxjava2:rxandroid:2.1.1'
     // coroutines
     implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-android:1.4.2'
 
@@ -88,20 +86,20 @@ dependencies {
 
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
 
-    implementation 'androidx.lifecycle:lifecycle-extensions:2.0.0'
+    implementation 'androidx.lifecycle:lifecycle-extensions:2.2.0'
     implementation 'androidx.legacy:legacy-support-v4:1.0.0'
-    implementation 'androidx.recyclerview:recyclerview:1.0.0'
+    implementation 'androidx.recyclerview:recyclerview:1.1.0'
 
     // Epoxy
-    implementation 'com.airbnb.android:epoxy:3.8.0'
-    implementation 'com.airbnb.android:epoxy-databinding:3.8.0'
-    kapt 'com.airbnb.android:epoxy-processor:3.8.0'
+    implementation 'com.airbnb.android:epoxy:3.9.0'
+    implementation 'com.airbnb.android:epoxy-databinding:3.9.0'
+    kapt 'com.airbnb.android:epoxy-processor:3.9.0'
 
     // In-App Review
-    implementation 'com.google.android.play:core:1.9.0'
+    implementation 'com.google.android.play:core:1.9.1'
     implementation 'com.google.android.play:core-ktx:1.8.1'
 
-    testImplementation 'junit:junit:4.12'
+    testImplementation 'junit:junit:4.13.1'
     androidTestImplementation('androidx.test.espresso:espresso-core:3.1.0', {
         exclude group: 'com.android.support', module: 'support-annotations'
     })

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -34,8 +34,9 @@ android {
             ext.enableCrashlytics = false
         }
     }
-    dataBinding {
-        enabled = true
+    buildFeatures {
+        dataBinding = true
+        viewBinding = true
     }
     kotlinOptions {
         jvmTarget = '1.8'

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -17,12 +17,7 @@ android {
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables.useSupportLibrary = true
         multiDexEnabled true
-
-        javaCompileOptions {
-            annotationProcessorOptions {
-                includeCompileClasspath = true
-            }
-        }
+        
     }
     buildTypes {
         release {

--- a/app/src/main/java/com/ikmr/banbara23/yaeyama_liner_checker/ui/dashboard/DashBoardFragment.kt
+++ b/app/src/main/java/com/ikmr/banbara23/yaeyama_liner_checker/ui/dashboard/DashBoardFragment.kt
@@ -1,0 +1,34 @@
+package com.ikmr.banbara23.yaeyama_liner_checker.ui.dashboard
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.fragment.app.Fragment
+import androidx.lifecycle.ViewModelProvider
+import com.ikmr.banbara23.yaeyama_liner_checker.R
+
+/**
+ * トップに表示するステータスのダッシュボード画面
+ */
+class DashBoardFragment : Fragment() {
+
+    private lateinit var viewModel: DashBoardViewModel
+
+    override fun onCreateView(
+        inflater: LayoutInflater, container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View? {
+        return inflater.inflate(R.layout.dash_board_fragment, container, false)
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        viewModel = ViewModelProvider(this).get(DashBoardViewModel::class.java)
+        // TODO: Use the ViewModel
+    }
+
+    companion object {
+        fun newInstance() = DashBoardFragment()
+    }
+}

--- a/app/src/main/java/com/ikmr/banbara23/yaeyama_liner_checker/ui/dashboard/DashBoardViewModel.kt
+++ b/app/src/main/java/com/ikmr/banbara23/yaeyama_liner_checker/ui/dashboard/DashBoardViewModel.kt
@@ -1,0 +1,10 @@
+package com.ikmr.banbara23.yaeyama_liner_checker.ui.dashboard
+
+import androidx.lifecycle.ViewModel
+
+/**
+ * トップに表示するステータスのダッシュボード ViewModel
+ */
+class DashBoardViewModel : ViewModel() {
+    // TODO: Implement the ViewModel
+}

--- a/app/src/main/res/layout/dash_board_fragment.xml
+++ b/app/src/main/res/layout/dash_board_fragment.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<FrameLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    tools:context=".ui.dashboard.DashBoardFragment"
+    >
+
+    <TextView
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:text="Hello"
+        />
+
+</FrameLayout>

--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 
 buildscript {
-    ext.kotlin_version = '1.4.0'
+    ext.kotlin_version = '1.4.30'
     ext.gradlePluginVersion = '4.1.2'
     repositories {
         google()

--- a/build.gradle
+++ b/build.gradle
@@ -12,11 +12,11 @@ buildscript {
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
-        classpath 'com.google.gms:google-services:4.3.3'
+        classpath 'com.google.gms:google-services:4.3.5'
 
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
-        classpath "androidx.navigation:navigation-safe-args-gradle-plugin:2.3.0-alpha06"
-        classpath 'com.google.firebase:firebase-crashlytics-gradle:2.3.0'
+        classpath "androidx.navigation:navigation-safe-args-gradle-plugin:2.3.3"
+        classpath 'com.google.firebase:firebase-crashlytics-gradle:2.4.1'
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,7 @@
 
 buildscript {
     ext.kotlin_version = '1.4.0'
-    ext.gradlePluginVersion = '4.1.0'
+    ext.gradlePluginVersion = '4.1.2'
     repositories {
         google()
         jcenter()


### PR DESCRIPTION
## やったこと
Kotlinを1.4.30
gradle plugin 4.1.2
残りも最新化

## 未解決
以下メッセージが解決できない
```
The 'kotlin-android-extensions' Gradle plugin is deprecated. Please use this migration guide (https://goo.gle/kotlin-android-extensions-deprecation) to start working with View Binding (https://developer.android.com/topic/libraries/view-binding) and the 'kotlin-parcelize' plugin.
API 'BaseVariant.getApplicationIdTextResource' is obsolete and has been replaced with 'VariantProperties.applicationId'.
```