### PR TITLE
EventでLiveDataをwrapしてSingleLiveDataとして処理する

### DIFF
--- a/app/src/main/java/com/ikmr/banbara23/yaeyama_liner_checker/core/Event.kt
+++ b/app/src/main/java/com/ikmr/banbara23/yaeyama_liner_checker/core/Event.kt
@@ -27,3 +27,5 @@ open class Event<out T>(private val content: T) {
      */
     fun peekContent(): T = content
 }
+
+fun <T : Any> T.toEvent(): Event<T> = Event(this)

--- a/app/src/main/java/com/ikmr/banbara23/yaeyama_liner_checker/core/Event.kt
+++ b/app/src/main/java/com/ikmr/banbara23/yaeyama_liner_checker/core/Event.kt
@@ -1,0 +1,29 @@
+package com.ikmr.banbara23.yaeyama_liner_checker.core
+
+/**
+ * Used as a wrapper for data that is exposed via a LiveData that represents an event.
+ *
+ * https://medium.com/androiddevelopers/livedata-with-snackbar-navigation-and-other-events-the-singleliveevent-case-ac2622673150
+ */
+open class Event<out T>(private val content: T) {
+
+    var hasBeenHandled = false
+        private set // Allow external read but not write
+
+    /**
+     * Returns the content and prevents its use again.
+     */
+    fun getContentIfNotHandled(): T? {
+        return if (hasBeenHandled) {
+            null
+        } else {
+            hasBeenHandled = true
+            content
+        }
+    }
+
+    /**
+     * Returns the content, even if it's already been handled.
+     */
+    fun peekContent(): T = content
+}

--- a/app/src/main/java/com/ikmr/banbara23/yaeyama_liner_checker/ext/LiveDataExt.kt
+++ b/app/src/main/java/com/ikmr/banbara23/yaeyama_liner_checker/ext/LiveDataExt.kt
@@ -1,0 +1,15 @@
+package com.ikmr.banbara23.yaeyama_liner_checker.ext
+
+import androidx.lifecycle.LifecycleOwner
+import androidx.lifecycle.LiveData
+import com.ikmr.banbara23.yaeyama_liner_checker.core.Event
+
+/**
+ * Eventを通してLiveDataを購読する
+ */
+fun <T> LiveData<Event<T>>.observeEvent(lifecycleOwner: LifecycleOwner, block: (T) -> Unit) {
+    observe(lifecycleOwner) { event ->
+        // 実行していなければblockを実行する、実行済みならnullが返って動かない
+        event?.getContentIfNotHandled()?.let(block)
+    }
+}

--- a/app/src/main/java/com/ikmr/banbara23/yaeyama_liner_checker/ui/dashboard/AbstractDashBoardViewModel.kt
+++ b/app/src/main/java/com/ikmr/banbara23/yaeyama_liner_checker/ui/dashboard/AbstractDashBoardViewModel.kt
@@ -2,12 +2,13 @@ package com.ikmr.banbara23.yaeyama_liner_checker.ui.dashboard
 
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.ViewModel
+import com.ikmr.banbara23.yaeyama_liner_checker.core.Event
 import com.ikmr.banbara23.yaeyama_liner_checker.model.top.Ports
 import com.ikmr.banbara23.yaeyama_liner_checker.model.top.TopPort
 
 abstract class DashBoardViewModel : ViewModel() {
     abstract val uiState: LiveData<TopPort>
-    abstract val nav: LiveData<DashBoardViewModelImpl.Nav>
+    abstract val nav: LiveData<Event<DashBoardViewModelImpl.Nav>>
 
     abstract fun onClickPort(ports: Ports)
 }

--- a/app/src/main/java/com/ikmr/banbara23/yaeyama_liner_checker/ui/dashboard/DashBoardFragment.kt
+++ b/app/src/main/java/com/ikmr/banbara23/yaeyama_liner_checker/ui/dashboard/DashBoardFragment.kt
@@ -8,6 +8,7 @@ import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
 import androidx.navigation.fragment.findNavController
 import com.ikmr.banbara23.yaeyama_liner_checker.databinding.DashBoardFragmentBinding
+import com.ikmr.banbara23.yaeyama_liner_checker.ext.observeEvent
 import timber.log.Timber
 
 /**
@@ -35,7 +36,7 @@ class DashBoardFragment : Fragment() {
             binding.topPort = it
         }
         viewModel.fetchTopPortStatus()
-        viewModel.nav.observe(viewLifecycleOwner, this::onNavigate)
+        viewModel.nav.observeEvent(viewLifecycleOwner, this::onNavigate)
     }
 
     /**

--- a/app/src/main/java/com/ikmr/banbara23/yaeyama_liner_checker/ui/dashboard/DashBoardViewModel.kt
+++ b/app/src/main/java/com/ikmr/banbara23/yaeyama_liner_checker/ui/dashboard/DashBoardViewModel.kt
@@ -4,6 +4,8 @@ import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.viewModelScope
 import com.google.firebase.database.DatabaseReference
 import com.google.firebase.database.FirebaseDatabase
+import com.ikmr.banbara23.yaeyama_liner_checker.core.Event
+import com.ikmr.banbara23.yaeyama_liner_checker.core.toEvent
 import com.ikmr.banbara23.yaeyama_liner_checker.model.top.Ports
 import com.ikmr.banbara23.yaeyama_liner_checker.model.top.TopPort
 import com.ikmr.banbara23.yaeyama_liner_checker.repository.TopPortStatusRepository
@@ -17,7 +19,7 @@ import timber.log.Timber
 class DashBoardViewModelImpl : DashBoardViewModel() {
 
     override val uiState = MutableLiveData<TopPort>()
-    override val nav = MutableLiveData<Nav>()
+    override val nav = MutableLiveData<Event<Nav>>()
 
     private val database: DatabaseReference by lazy {
         FirebaseDatabase.getInstance().reference.ref.child("top_port")
@@ -43,7 +45,7 @@ class DashBoardViewModelImpl : DashBoardViewModel() {
      */
     override fun onClickPort(ports: Ports) {
         Timber.d("clicked: $ports")
-        nav.value = Nav.GoDetail(ports)
+        nav.value = Nav.GoDetail(ports).toEvent()
     }
 
     sealed class Nav {


### PR DESCRIPTION
## やったこと
以下を参考にEventクラスを作成
画面遷移LiveDataをEventを通して処理するようにした

LiveData with SnackBar, Navigation and other events (the SingleLiveEvent case) | by Jose Alcérreca | Android Developers | Medium https://medium.com/androiddevelopers/livedata-with-snackbar-navigation-and-other-events-the-singleliveevent-case-ac2622673150

## なぜ使うのか？
簡単にいうと、前の画面に戻れない
トップの運行画面でLiveDataをトリガーとして画面遷移するNavを作成したが、遷移後の画面から戻ると`Fragment#onCreateView`が再度呼び出され、再び遷移してしまう。
