### PR TITLE
トップ画面でヌルポが発生してるので修正

### DIFF
--- a/app/src/main/java/com/ikmr/banbara23/yaeyama_liner_checker/ui/dashboard/AbstractDashBoardViewModel.kt
+++ b/app/src/main/java/com/ikmr/banbara23/yaeyama_liner_checker/ui/dashboard/AbstractDashBoardViewModel.kt
@@ -10,5 +10,5 @@ abstract class DashBoardViewModel : ViewModel() {
     abstract val uiState: LiveData<TopPort>
     abstract val nav: LiveData<Event<DashBoardViewModelImpl.Nav>>
 
-    abstract fun onClickPort(ports: Ports)
+    abstract fun onClickPort(ports: Ports?)
 }

--- a/app/src/main/java/com/ikmr/banbara23/yaeyama_liner_checker/ui/dashboard/DashBoardViewModel.kt
+++ b/app/src/main/java/com/ikmr/banbara23/yaeyama_liner_checker/ui/dashboard/DashBoardViewModel.kt
@@ -43,8 +43,9 @@ class DashBoardViewModelImpl : DashBoardViewModel() {
     /**
      * 港クリック
      */
-    override fun onClickPort(ports: Ports) {
+    override fun onClickPort(ports: Ports?) {
         Timber.d("clicked: $ports")
+        ports ?: return
         nav.value = Nav.GoDetail(ports).toEvent()
     }
 


### PR DESCRIPTION
## やったこと

crashlytics でトップでヌルポが発生しているメールがきた
通信が遅い環境で読み込み中に、港をクリックすると落ちる

いったん変数をnullableにして対応した

## エラーログ
```
Fatal Exception: java.lang.NullPointerException: Parameter specified as non-null is null: method kotlin.jvm.internal.Intrinsics.checkNotNullParameter, parameter ports
       at com.ikmr.banbara23.yaeyama_liner_checker.ui.dashboard.DashBoardViewModelImpl.onClickPort(DashBoardViewModel.kt)
       at com.ikmr.banbara23.yaeyama_liner_checker.databinding.DashBoardPortListItemBindingImpl._internalCallbackOnClick(DashBoardPortListItemBindingImpl.java:199)
       at com.ikmr.banbara23.yaeyama_liner_checker.generated.callback.OnClickListener.onClick(OnClickListener.java:11)
       at android.view.View.performClick(View.java:5204)
       at android.view.View$PerformClick.run(View.java:21153)
       at android.os.Handler.handleCallback(Handler.java:739)
       at android.os.Handler.dispatchMessage(Handler.java:95)
       at android.os.Looper.loop(Looper.java:148)
       at android.app.ActivityThread.main(ActivityThread.java:5421)
       at java.lang.reflect.Method.invoke(Method.java)
       at com.android.internal.os.ZygoteInit$MethodAndArgsCaller.run(ZygoteInit.java:726)
       at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:616)
```

https://console.firebase.google.com/project/yaima-funi/crashlytics/app/android:com.banbara.yaeyama.liner.checker/issues?time=last-seven-days