### PR TITLE
天気画面を修正

### DIFF
--- a/app/src/main/java/com/ikmr/banbara23/yaeyama_liner_checker/ui/weather/WeatherFragment.kt
+++ b/app/src/main/java/com/ikmr/banbara23/yaeyama_liner_checker/ui/weather/WeatherFragment.kt
@@ -47,6 +47,7 @@ class WeatherFragment : Fragment(R.layout.weather_fragment) {
         }
 
         setupViewModel()
+        binding.weather = WeatherInfo() // null文字の表示対策、いつか対応して消したい
     }
 
     private fun setupViewModel() {
@@ -73,6 +74,7 @@ class WeatherFragment : Fragment(R.layout.weather_fragment) {
     }
 
     private fun bindData(weather: WeatherInfo) {
+        Timber.d(weather.toString())
         binding.weather = weather // TODO:エラー解決したい
         (binding.today.timeList.adapter as WeatherTimeListAdaptor).update(weather.today.table)
         (binding.today.timeList.adapter as WeatherTimeListAdaptor).update(weather.tomorrow.table)

--- a/app/src/main/res/layout/weather_fragment.xml
+++ b/app/src/main/res/layout/weather_fragment.xml
@@ -28,6 +28,7 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:orientation="vertical"
+            android:paddingBottom="60dp"
             >
 
             <androidx.appcompat.widget.Toolbar
@@ -63,10 +64,10 @@
             <Button
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:layout_marginLeft="16dp"
-                android:layout_marginTop="8dp"
-                android:layout_marginRight="16dp"
                 android:layout_marginBottom="8dp"
+                android:layout_marginLeft="16dp"
+                android:layout_marginRight="16dp"
+                android:layout_marginTop="8dp"
                 android:background="#F7A325"
                 android:onClick="@{() -> viewModel.moreButtonClick()}"
                 android:text="天気を詳しく見る"

--- a/shared/src/commonMain/kotlin/com/ikemura/shared/model/weather/Table.kt
+++ b/shared/src/commonMain/kotlin/com/ikemura/shared/model/weather/Table.kt
@@ -8,11 +8,11 @@ import kotlinx.serialization.Serializable
 @Serializable
 data class Table(
     // 時間
-    var hour: String = "",
+    val hour: String = "",
     // 天気
-    var weather: String = "",
+    val weather: String = "",
     // 風向き
-    var windBlow: String = "",
+    val windBlow: String = "",
     // 風速
-    var windSpeed: String = ""
+    val windSpeed: String = ""
 )

--- a/shared/src/commonMain/kotlin/com/ikemura/shared/model/weather/Temperature.kt
+++ b/shared/src/commonMain/kotlin/com/ikemura/shared/model/weather/Temperature.kt
@@ -8,7 +8,7 @@ import kotlinx.serialization.Serializable
 @Serializable
 data class Temperature(
     // 最高
-    var hight: String = "",
+    val hight: String = "",
     // 最低
-    var low: String = ""
+    val low: String = ""
 )

--- a/shared/src/commonMain/kotlin/com/ikemura/shared/model/weather/Weather.kt
+++ b/shared/src/commonMain/kotlin/com/ikemura/shared/model/weather/Weather.kt
@@ -8,15 +8,15 @@ import kotlinx.serialization.Serializable
 @Serializable
 data class Weather(
     // 日付
-    var date: String = "",
+    val date: String = "",
     // 3時間毎の天気
-    var table: List<Table> = listOf(),
+    val table: List<Table> = listOf(),
     // 気温（最低＋最高）
-    var temperature: Temperature = Temperature(),
+    val temperature: Temperature = Temperature(),
     // 波の高さ
-    var wave: String = "",
+    val wave: String = "",
     // 天気
-    var weather: String = "",
+    val weather: String = "",
     // 風速
-    var wind: String = "",
+    val wind: String = "",
 )


### PR DESCRIPTION
## やったこと

天気画面の修正

- 隠れていた「天気を詳しくみるボタン」を表示させた（BottomMenuの後ろに隠れてた）
- 天気の値が null が一瞬みえるので、表示させないようにした

### 修正前
<img src=https://user-images.githubusercontent.com/8417910/110222629-eef56600-7f16-11eb-840d-844788eda929.png  width=50%>

<details><summary>GIF</summary>
<p>

![2021-03-07-07-29-01](https://user-images.githubusercontent.com/8417910/110223829-fbc78900-7f19-11eb-92a9-18905bee72c5.gif)

</p>
</details>

<img src=https://user-images.githubusercontent.com/8417910/110223854-29accd80-7f1a-11eb-945d-19f7ab6683da.png  width=50%>


### 修正後

![2021-03-07-07-52-43](https://user-images.githubusercontent.com/8417910/110223849-20236580-7f1a-11eb-9329-4c9174686858.gif)


