### PR TITLE
refactor: RepositoryでFlowを再作成しないようにした

### DIFF
--- a/shared/src/commonMain/kotlin/com/ikemura/shared/repository/StatusDetailRepository.kt
+++ b/shared/src/commonMain/kotlin/com/ikemura/shared/repository/StatusDetailRepository.kt
@@ -8,8 +8,10 @@ import dev.gitlive.firebase.app
 import dev.gitlive.firebase.database.FirebaseDatabase
 import dev.gitlive.firebase.database.database
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.map
 
 class StatusDetailRepository {
     // Firebase Realtime Database
@@ -21,10 +23,12 @@ class StatusDetailRepository {
     fun fetchStatusDetail(company: Company, portCode: String): Flow<UiState<PortStatus>> = flow {
         val path = "${company.code}/$portCode"
         val dbRef = database.reference(path)
-        dbRef.valueEvents.collect {
-            val portStatus = it.value(PortStatus.serializer())
-            emit(UiState.Success(portStatus))
-        }
+        dbRef.valueEvents
+            .map {
+                val deserializeValue = it.value(PortStatus.serializer())
+                UiState.Success(deserializeValue)
+            }
+            .catch { UiState.Error(it) }
     }
 
     fun fetchTimeTable(company: Company, portCode: String): Flow<UiState<TimeTable>> = flow {

--- a/shared/src/commonMain/kotlin/com/ikemura/shared/repository/StatusDetailRepository.kt
+++ b/shared/src/commonMain/kotlin/com/ikemura/shared/repository/StatusDetailRepository.kt
@@ -9,7 +9,6 @@ import dev.gitlive.firebase.database.FirebaseDatabase
 import dev.gitlive.firebase.database.database
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.catch
-import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.map
 
@@ -34,9 +33,11 @@ class StatusDetailRepository {
     fun fetchTimeTable(company: Company, portCode: String): Flow<UiState<TimeTable>> = flow {
         val path = "${company.code}_timeTable/$portCode"
         val dbRef = database.reference(path)
-        dbRef.valueEvents.collect {
-            val data = it.value(TimeTable.serializer())
-            emit(UiState.Success(data))
-        }
+        dbRef.valueEvents
+            .map {
+                val deserializeValue = it.value(TimeTable.serializer())
+                UiState.Success(deserializeValue)
+            }
+            .catch { UiState.Error(it) }
     }
 }

--- a/shared/src/commonMain/kotlin/com/ikemura/shared/repository/WeatherRepository.kt
+++ b/shared/src/commonMain/kotlin/com/ikemura/shared/repository/WeatherRepository.kt
@@ -13,7 +13,6 @@ import kotlinx.coroutines.flow.map
 /**
  * 天気 Repository
  */
-@Suppress("EXPERIMENTAL_API_USAGE")
 class WeatherRepository(
     // TODO: DIする
 //    private val dbRef: DatabaseReference

--- a/shared/src/commonMain/kotlin/com/ikemura/shared/repository/WeatherRepository.kt
+++ b/shared/src/commonMain/kotlin/com/ikemura/shared/repository/WeatherRepository.kt
@@ -2,15 +2,13 @@ package com.ikemura.shared.repository
 
 import com.ikemura.shared.model.weather.WeatherInfo
 import dev.gitlive.firebase.Firebase
-import dev.gitlive.firebase.FirebaseApp
 import dev.gitlive.firebase.app
 import dev.gitlive.firebase.database.DataSnapshot
-import dev.gitlive.firebase.database.DatabaseReference
-import dev.gitlive.firebase.database.FirebaseDatabase
 import dev.gitlive.firebase.database.database
-import kotlinx.coroutines.channels.awaitClose
-import kotlinx.coroutines.flow.*
-import kotlinx.serialization.DeserializationStrategy
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.catch
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.map
 
 /**
  * 天気 Repository
@@ -26,10 +24,14 @@ class WeatherRepository(
      */
     fun fetchWeather(): Flow<WeatherUiState> = flow {
         val dbRef = Firebase.database(Firebase.app).reference("weather")
-        dbRef.valueEvents.collect { snapShot: DataSnapshot ->
-            val weather = snapShot.value(WeatherInfo.serializer())
-            emit(WeatherUiState.Success(weather))
-        }
+        dbRef.valueEvents
+            .map { snapShot: DataSnapshot ->
+                val deserializeValue = snapShot.value(WeatherInfo.serializer())
+                UiState.Success(deserializeValue)
+            }
+            .catch {
+                UiState.Error(it)
+            }
     }
 
 //    /**


### PR DESCRIPTION
これまではfirebaseの接続部分で`flow{}`を再作成してたが、
Flowのオペレーターをうまく使って再作成しないようにした