### PR TITLE
gradlePluginを7.1.2にあげる

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -45,7 +45,6 @@ android {
     }
     kotlinOptions {
         jvmTarget = "1.8"
-        useIR = true
     }
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_1_8

--- a/buildSrc/src/main/kotlin/Versions.kt
+++ b/buildSrc/src/main/kotlin/Versions.kt
@@ -1,5 +1,5 @@
 object Versions {
-    const val gradlePlugin = "7.0.4"
+    const val gradlePlugin = "7.1.2"
     const val kotlin = "1.5.21"
     const val compose = "1.0.1"
     const val navigation = "2.3.5"

--- a/buildSrc/src/main/kotlin/Versions.kt
+++ b/buildSrc/src/main/kotlin/Versions.kt
@@ -2,7 +2,7 @@ object Versions {
     const val gradlePlugin = "7.1.2"
     const val kotlin = "1.5.21"
     const val compose = "1.0.1"
-    const val navigation = "2.3.5"
+    const val navigation = "2.4.1"
     const val firebaseCrashlyticsGradle = "2.7.1"
     const val googleServices = "4.3.10"
     const val coroutine = "1.5.1"

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.2-bin.zip


### PR DESCRIPTION
Android Studioのpopupから更新した。

すると以下のエラーになりビルドが通らなくなった、

```
./gradlew :app:mergeDebugResources

> Configure project :app
WARNING:API 'BaseVariant.getApplicationIdTextResource' is obsolete and has been replaced with 'VariantProperties.applicationId'.
It will be removed in version 7.0 of the Android Gradle plugin.
For more information, see TBD.
To determine what is calling BaseVariant.getApplicationIdTextResource, use -Pandroid.debug.obsoleteApi=true on the command line to display more information.

```