### PR TITLE
fix: Android Studio Ladybugのビルドエラー対応

### DIFF
--- a/androidApp/build.gradle.kts
+++ b/androidApp/build.gradle.kts
@@ -43,10 +43,6 @@ android {
         viewBinding = true
         compose = true
     }
-    compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_21
-        targetCompatibility = JavaVersion.VERSION_21
-    }
     composeOptions {
         // 互換性のあるCompatible Kotlin Versionと合わせること
         // https://developer.android.com/jetpack/androidx/releases/compose-kotlin
@@ -54,7 +50,9 @@ android {
     }
     namespace = "com.ikmr.banbara23.yaeyama_liner_checker"
 }
-
+kotlin {
+    jvmToolchain(17)
+}
 dependencies {
     implementation(project(":domain"))
     implementation(project(":data"))

--- a/androidApp/build.gradle.kts
+++ b/androidApp/build.gradle.kts
@@ -50,9 +50,7 @@ android {
     }
     namespace = "com.ikmr.banbara23.yaeyama_liner_checker"
 }
-kotlin {
-    jvmToolchain(17)
-}
+
 dependencies {
     implementation(project(":domain"))
     implementation(project(":data"))

--- a/androidApp/build.gradle.kts
+++ b/androidApp/build.gradle.kts
@@ -80,8 +80,8 @@ dependencies {
     implementation(libs.timber)
 
     // In-App Review
-    implementation(libs.play.core)
-    implementation(libs.play.core.ktx)
+    implementation(libs.play.review)
+    implementation(libs.play.review.ktx)
 
     // Jetpack Compose toolkit dependencies
     // https://developer.android.com/jetpack/compose/setup#compose-compiler

--- a/androidApp/build.gradle.kts
+++ b/androidApp/build.gradle.kts
@@ -44,8 +44,8 @@ android {
         compose = true
     }
     compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_17
-        targetCompatibility = JavaVersion.VERSION_17
+        sourceCompatibility = JavaVersion.VERSION_21
+        targetCompatibility = JavaVersion.VERSION_21
     }
     composeOptions {
         // 互換性のあるCompatible Kotlin Versionと合わせること

--- a/androidApp/src/main/java/com/yaeyama/linerchecker/ui/main/MainActivity.kt
+++ b/androidApp/src/main/java/com/yaeyama/linerchecker/ui/main/MainActivity.kt
@@ -10,10 +10,10 @@ import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.repeatOnLifecycle
 import androidx.navigation.fragment.NavHostFragment
 import androidx.navigation.ui.setupWithNavController
+import com.google.android.gms.tasks.Task
 import com.google.android.material.bottomnavigation.BottomNavigationView
 import com.google.android.play.core.review.ReviewInfo
 import com.google.android.play.core.review.ReviewManager
-import com.google.android.play.core.tasks.Task
 import com.ikmr.banbara23.yaeyama_liner_checker.R
 import com.ikmr.banbara23.yaeyama_liner_checker.databinding.MainActivityBinding
 import kotlinx.coroutines.launch

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,3 +1,7 @@
+import org.jetbrains.kotlin.gradle.dsl.KotlinAndroidProjectExtension
+import org.jetbrains.kotlin.gradle.dsl.KotlinJvmProjectExtension
+import org.jetbrains.kotlin.gradle.plugin.KotlinBasePluginWrapper
+
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 
 buildscript {
@@ -22,6 +26,19 @@ allprojects {
         maven("https://jitpack.io")
         maven("https://maven.google.com")
         mavenCentral()
+    }
+}
+
+subprojects {
+    plugins.withId("org.jetbrains.kotlin.android") {
+        extensions.configure<KotlinAndroidProjectExtension> {
+            jvmToolchain(17)
+        }
+    }
+    plugins.withId("org.jetbrains.kotlin.jvm") {
+        extensions.configure<KotlinJvmProjectExtension> {
+            jvmToolchain(17)
+        }
     }
 }
 

--- a/data/build.gradle.kts
+++ b/data/build.gradle.kts
@@ -11,10 +11,6 @@ android {
     }
 }
 
-kotlin {
-    jvmToolchain(17)
-}
-
 dependencies {
     implementation(libs.koin.core)
 

--- a/data/build.gradle.kts
+++ b/data/build.gradle.kts
@@ -6,7 +6,9 @@ plugins {
 android {
     namespace = "com.yaeyama.linerchecker"
     compileSdk = libs.versions.app.compileSdk.get().toInt()
-
+    defaultConfig {
+        minSdk = libs.versions.app.minSdk.get().toInt()
+    }
     // Unitテストで使う
     kotlinOptions {
         jvmTarget = "1.8"

--- a/data/build.gradle.kts
+++ b/data/build.gradle.kts
@@ -9,10 +9,10 @@ android {
     defaultConfig {
         minSdk = libs.versions.app.minSdk.get().toInt()
     }
-    // Unitテストで使う
-    kotlinOptions {
-        jvmTarget = "1.8"
-    }
+}
+
+kotlin {
+    jvmToolchain(17)
 }
 
 dependencies {

--- a/domain/build.gradle.kts
+++ b/domain/build.gradle.kts
@@ -1,3 +1,6 @@
 plugins {
     kotlin("jvm")
 }
+kotlin {
+    jvmToolchain(17)
+}

--- a/domain/build.gradle.kts
+++ b/domain/build.gradle.kts
@@ -1,6 +1,3 @@
 plugins {
     kotlin("jvm")
 }
-kotlin {
-    jvmToolchain(17)
-}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -24,8 +24,8 @@ materialIconsCore = "1.6.2"
 materialIconsExtended = "1.6.2"
 navigationFragmentKtx = "2.7.7"
 navigationUiKtx = "2.7.7"
-playCore = "1.10.3"
-playCoreKtx = "1.8.1"
+playReview = "2.0.2"
+playReviewKtx = "2.0.2"
 firebaseBom = "32.7.2"
 androidGradlePlugin = "8.3.0"
 googleServices = "4.4.1"
@@ -57,8 +57,8 @@ navigation-fragment-ktx = { module = "androidx.navigation:navigation-fragment-kt
 navigation-runtime-ktx = { module = "androidx.navigation:navigation-runtime-ktx", version.ref = "navigationUiKtx" }
 navigation-safe-args-gradle-plugin = { module = "androidx.navigation:navigation-safe-args-gradle-plugin", version.ref = "navigationUiKtx" }
 navigation-ui-ktx = { module = "androidx.navigation:navigation-ui-ktx", version.ref = "navigationUiKtx" }
-play-core = { module = "com.google.android.play:core", version.ref = "playCore" }
-play-core-ktx = { module = "com.google.android.play:core-ktx", version.ref = "playCoreKtx" }
+play-review = { module = "com.google.android.play:review", version.ref = "playReview" }
+play-review-ktx = { module = "com.google.android.play:review-ktx", version.ref = "playReviewKtx" }
 firebase-bom = { group = "com.google.firebase", name = "firebase-bom", version.ref = "firebaseBom" }
 firebase-database = {group = "com.google.firebase", name = "firebase-database-ktx"}
 firebase-analytics = {group = "com.google.firebase", name = "firebase-analytics-ktx"}


### PR DESCRIPTION
## 概要

Android Studioをアプデしたらビルドエラーになったので、以下の対応した

- jvm 21を指定
- dataモジュールにminSdk 21を指定

## スクリーンショット

| Before | After |
|--------|-------|
|  |  |

## 備考
