### PR TITLE
fix: ダッシュボード画面が小さい端末で見切れる不具合を修正した

### DIFF
--- a/androidApp/src/main/java/com/yaeyama/linerchecker/ui/dashboard/DashBoardPage.kt
+++ b/androidApp/src/main/java/com/yaeyama/linerchecker/ui/dashboard/DashBoardPage.kt
@@ -3,7 +3,9 @@ package com.yaeyama.linerchecker.ui.dashboard
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.Card
 import androidx.compose.material.Divider
 import androidx.compose.material.Surface
@@ -28,7 +30,9 @@ fun DashBoardPage(
         modifier = modifier.fillMaxWidth(),
         shape = RoundedCornerShape(8.dp),
     ) {
-        Column {
+        Column(
+            modifier = Modifier.verticalScroll(rememberScrollState()) // スクロール可能にする
+        ) {
             DashBoardHeader()
             ports.forEach { p ->
                 RowDivider()

--- a/androidApp/src/main/java/com/yaeyama/linerchecker/ui/dashboard/DashBoardScreen.kt
+++ b/androidApp/src/main/java/com/yaeyama/linerchecker/ui/dashboard/DashBoardScreen.kt
@@ -8,6 +8,7 @@ import androidx.compose.runtime.State
 import androidx.compose.runtime.collectAsState
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.tooling.preview.Devices
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.yaeyama.linerchecker.ui.dashboard.component.DashBoardAppBar
@@ -56,6 +57,25 @@ private fun DashBoardScreen(
 @Preview(showBackground = true, backgroundColor = 0xFF0000FF)
 @Composable
 private fun DashBoardScreenPreview() {
+    YaimafuniAndroidTheme {
+        DashBoardScreen(
+            uiState = DashBoardUiState(
+                isLoading = false,
+                isError = false,
+                portList = FakeDashBoardDataProvider.dummyPortList,
+            ),
+            onRowClick = {},
+        )
+    }
+}
+
+@Preview(
+    name = "Small Phone",
+    showBackground = false,
+    widthDp = 320,
+    heightDp = 480)
+@Composable
+private fun DashBoardScreenSmallDevicePreview() {
     YaimafuniAndroidTheme {
         DashBoardScreen(
             uiState = DashBoardUiState(


### PR DESCRIPTION
## 概要
とりあえずスクロールできるようにした

## 関連するIssue
- close https://github.com/ikemura23/Yaimafuni-Android/issues/142

## スクリーンショット

| Before | After |
|--------|-------|
| <img src=https://github.com/user-attachments/assets/800c0163-2c25-4702-a51f-9dc23855d74b  width=50%> | <img src=https://github.com/user-attachments/assets/e36f445f-e650-4fb7-b41a-351c5fe8b1f5  width=50%> |

## 備考
