### PR TITLE
convention plugin を導入

### DIFF
--- a/androidApp/build.gradle.kts
+++ b/androidApp/build.gradle.kts
@@ -1,56 +1,23 @@
 import com.google.firebase.crashlytics.buildtools.gradle.CrashlyticsExtension
 
 plugins {
-    id("com.android.application")
-    id("com.google.gms.google-services") // firebaseに必要
-    kotlin("android")
-    id("kotlin-kapt")
-    id("kotlin-parcelize")
-    id("com.google.firebase.crashlytics")
-    id("androidx.navigation.safeargs.kotlin")
+    id("yaeyama.android.application")
 }
 
 android {
-    compileSdk = libs.versions.app.compileSdk.get().toInt()
-
+    namespace = "com.ikmr.banbara23.yaeyama_liner_checker"
+    
     defaultConfig {
         applicationId = "com.banbara.yaeyama.liner.checker"
-        minSdk = libs.versions.app.minSdk.get().toInt()
-        targetSdk = libs.versions.app.targetSdk.get().toInt()
         versionCode = 94
         versionName = "4.8.0"
-        testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
-        vectorDrawables.useSupportLibrary = true
     }
+    
     buildTypes {
-        release {
-            isMinifyEnabled = false
-            proguardFiles(getDefaultProguardFile("proguard-android.txt"), "proguard-rules.pro")
-            signingConfig = signingConfigs.getByName("debug")
-        }
         debug {
-            isMinifyEnabled = false
-            proguardFiles(getDefaultProguardFile("proguard-android.txt"), "proguard-rules.pro")
             applicationIdSuffix = ".debug"
-            configure<CrashlyticsExtension> {
-                // マッピング ファイルを Crashlytics にアップロードしない
-                // https://firebase.google.com/docs/crashlytics/upgrade-sdk?hl=ja&platform=android
-                mappingFileUploadEnabled = false
-            }
         }
     }
-    buildFeatures {
-        dataBinding = true
-        viewBinding = true
-        compose = true
-        buildConfig = true
-    }
-    composeOptions {
-        // 互換性のあるCompatible Kotlin Versionと合わせること
-        // https://developer.android.com/jetpack/androidx/releases/compose-kotlin
-        kotlinCompilerExtensionVersion = libs.versions.compose.compiler.version.get()
-    }
-    namespace = "com.ikmr.banbara23.yaeyama_liner_checker"
 }
 
 dependencies {

--- a/androidApp/build.gradle.kts
+++ b/androidApp/build.gradle.kts
@@ -1,18 +1,16 @@
-import com.google.firebase.crashlytics.buildtools.gradle.CrashlyticsExtension
-
 plugins {
     id("yaeyama.android.application")
 }
 
 android {
     namespace = "com.ikmr.banbara23.yaeyama_liner_checker"
-    
+
     defaultConfig {
         applicationId = "com.banbara.yaeyama.liner.checker"
         versionCode = 94
         versionName = "4.8.0"
     }
-    
+
     buildTypes {
         debug {
             applicationIdSuffix = ".debug"

--- a/build-logic/convention/build.gradle.kts
+++ b/build-logic/convention/build.gradle.kts
@@ -1,0 +1,15 @@
+plugins {
+    `kotlin-dsl`
+}
+
+dependencies {
+    implementation(libs.gradle)
+    implementation(libs.kotlin.gradle.plugin)
+    implementation(libs.google.services)
+    implementation(libs.firebase.crashlytics.gradle)
+    implementation(libs.navigation.safe.args.gradle.plugin)
+}
+
+kotlin {
+    jvmToolchain(17)
+}

--- a/build-logic/convention/src/main/kotlin/yaeyama.android.application.gradle.kts
+++ b/build-logic/convention/src/main/kotlin/yaeyama.android.application.gradle.kts
@@ -1,0 +1,56 @@
+import com.android.build.gradle.internal.dsl.BaseAppModuleExtension
+import com.google.firebase.crashlytics.buildtools.gradle.CrashlyticsExtension
+import org.gradle.api.JavaVersion
+import org.gradle.kotlin.dsl.configure
+
+plugins {
+    id("com.android.application")
+    id("com.google.gms.google-services")
+    kotlin("android")
+    id("kotlin-kapt")
+    id("kotlin-parcelize")
+    id("com.google.firebase.crashlytics")
+    id("androidx.navigation.safeargs.kotlin")
+}
+
+configure<BaseAppModuleExtension> {
+    compileSdk = 35
+
+    defaultConfig {
+        minSdk = 24
+        targetSdk = 35
+        testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
+        vectorDrawables.useSupportLibrary = true
+    }
+
+    buildTypes {
+        release {
+            isMinifyEnabled = false
+            proguardFiles(getDefaultProguardFile("proguard-android.txt"), "proguard-rules.pro")
+            signingConfig = signingConfigs.getByName("debug")
+        }
+        debug {
+            isMinifyEnabled = false
+            proguardFiles(getDefaultProguardFile("proguard-android.txt"), "proguard-rules.pro")
+            configure<CrashlyticsExtension> {
+                mappingFileUploadEnabled = false
+            }
+        }
+    }
+
+    buildFeatures {
+        dataBinding = true
+        viewBinding = true
+        compose = true
+        buildConfig = true
+    }
+
+    composeOptions {
+        kotlinCompilerExtensionVersion = "1.5.14"
+    }
+
+    compileOptions {
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
+    }
+}

--- a/build-logic/convention/src/main/kotlin/yaeyama.android.library.gradle.kts
+++ b/build-logic/convention/src/main/kotlin/yaeyama.android.library.gradle.kts
@@ -1,0 +1,29 @@
+import com.android.build.gradle.LibraryExtension
+import org.gradle.api.JavaVersion
+import org.gradle.kotlin.dsl.configure
+
+plugins {
+    id("com.android.library")
+    kotlin("android")
+}
+
+configure<LibraryExtension> {
+    compileSdk = 35
+
+    defaultConfig {
+        minSdk = 24
+        testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
+    }
+
+    buildTypes {
+        release {
+            isMinifyEnabled = false
+            proguardFiles(getDefaultProguardFile("proguard-android-optimize.txt"), "proguard-rules.pro")
+        }
+    }
+
+    compileOptions {
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
+    }
+}

--- a/build-logic/convention/src/main/kotlin/yaeyama.kotlin.library.gradle.kts
+++ b/build-logic/convention/src/main/kotlin/yaeyama.kotlin.library.gradle.kts
@@ -1,0 +1,16 @@
+import org.gradle.api.JavaVersion
+import org.jetbrains.kotlin.gradle.dsl.KotlinJvmProjectExtension
+import org.gradle.kotlin.dsl.configure
+
+plugins {
+    kotlin("jvm")
+}
+
+configure<KotlinJvmProjectExtension> {
+    jvmToolchain(17)
+}
+
+java {
+    sourceCompatibility = JavaVersion.VERSION_17
+    targetCompatibility = JavaVersion.VERSION_17
+}

--- a/build-logic/convention/src/main/kotlin/yaeyama.kotlin.library.gradle.kts
+++ b/build-logic/convention/src/main/kotlin/yaeyama.kotlin.library.gradle.kts
@@ -1,6 +1,6 @@
 import org.gradle.api.JavaVersion
-import org.jetbrains.kotlin.gradle.dsl.KotlinJvmProjectExtension
 import org.gradle.kotlin.dsl.configure
+import org.jetbrains.kotlin.gradle.dsl.KotlinJvmProjectExtension
 
 plugins {
     kotlin("jvm")

--- a/build-logic/settings.gradle.kts
+++ b/build-logic/settings.gradle.kts
@@ -1,0 +1,15 @@
+dependencyResolutionManagement {
+    repositories {
+        google()
+        mavenCentral()
+        gradlePluginPortal()
+    }
+    versionCatalogs {
+        create("libs") {
+            from(files("../gradle/libs.versions.toml"))
+        }
+    }
+}
+
+rootProject.name = "build-logic"
+include(":convention")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,44 +1,9 @@
-import org.jetbrains.kotlin.gradle.dsl.KotlinAndroidProjectExtension
-import org.jetbrains.kotlin.gradle.dsl.KotlinJvmProjectExtension
-import org.jetbrains.kotlin.gradle.plugin.KotlinBasePluginWrapper
-
-// Top-level build file where you can add configuration options common to all sub-projects/modules.
-
-buildscript {
-    repositories {
-        google()
-        mavenCentral()
-    }
-    dependencies {
-        classpath(libs.gradle)
-        // NOTE: Do not place your application dependencies here; they belong
-        // in the individual module build.gradle files
-        classpath(libs.google.services)
-        classpath(libs.kotlin.gradle.plugin)
-        classpath(libs.navigation.safe.args.gradle.plugin)
-        classpath(libs.firebase.crashlytics.gradle)
-    }
-}
-
 allprojects {
     repositories {
         google()
         maven("https://jitpack.io")
         maven("https://maven.google.com")
         mavenCentral()
-    }
-}
-
-subprojects {
-    plugins.withId("org.jetbrains.kotlin.android") {
-        extensions.configure<KotlinAndroidProjectExtension> {
-            jvmToolchain(17)
-        }
-    }
-    plugins.withId("org.jetbrains.kotlin.jvm") {
-        extensions.configure<KotlinJvmProjectExtension> {
-            jvmToolchain(17)
-        }
     }
 }
 

--- a/data/build.gradle.kts
+++ b/data/build.gradle.kts
@@ -1,14 +1,9 @@
 plugins {
-    id("com.android.library")
-    id("org.jetbrains.kotlin.android")
+    id("yaeyama.android.library")
 }
 
 android {
     namespace = "com.yaeyama.linerchecker"
-    compileSdk = libs.versions.app.compileSdk.get().toInt()
-    defaultConfig {
-        minSdk = libs.versions.app.minSdk.get().toInt()
-    }
 }
 
 dependencies {

--- a/domain/build.gradle.kts
+++ b/domain/build.gradle.kts
@@ -1,3 +1,3 @@
 plugins {
-    kotlin("jvm")
+    id("yaeyama.kotlin.library")
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -75,6 +75,15 @@ viewpager2 = { module = "androidx.viewpager2:viewpager2", version.ref = "viewpag
 androidx-core = { group = "androidx.core", name = "core-ktx", version.ref = "androidxCoreKtx" }
 
 [plugins]
+android-application = { id = "com.android.application", version.ref = "androidGradlePlugin" }
+android-library = { id = "com.android.library", version.ref = "androidGradlePlugin" }
+kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlinGradlePlugin" }
+kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlinGradlePlugin" }
+kotlin-kapt = { id = "org.jetbrains.kotlin.kapt", version.ref = "kotlinGradlePlugin" }
+kotlin-parcelize = { id = "org.jetbrains.kotlin.plugin.parcelize", version.ref = "kotlinGradlePlugin" }
+google-services = { id = "com.google.gms.google-services", version.ref = "googleServices" }
+firebase-crashlytics = { id = "com.google.firebase.crashlytics", version.ref = "firebaseCrashlyticsGradle" }
+navigation-safe-args = { id = "androidx.navigation.safeargs.kotlin", version.ref = "navigationUiKtx" }
 
 [bundles]
 

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,4 +1,5 @@
 pluginManagement {
+    includeBuild("build-logic")
     repositories {
         google()
         gradlePluginPortal()


### PR DESCRIPTION
## 概要

Gradleビルドロジックを整理し、カスタムConvention Pluginを導入してビルド設定を標準化しました。

#### 主な変更内容

  - Convention Plugin システムの導入
    - build-logic/conventionモジュールを新規作成
    - アプリケーション用、Androidライブラリ用、Kotlinライブラリ用のConvention Pluginを実装
    - 共通ビルド設定の一元管理を実現
  - ビルドスクリプトの簡素化
    - androidApp/build.gradle.ktsを56行から23行に大幅簡素化
    - 各モジュールのビルドスクリプトでConvention Pluginを活用
    - 重複したビルド設定を削除
  - プラグイン管理の改善
    - gradle/libs.versions.tomlにプラグイン定義を追加
    - バージョン管理を一元化


## スクリーンショット
なし

## 備考
この変更により、今後の新しいモジュール追加やビルド設定変更時の保守性が大幅に向上します。
各モジュールのビルドスクリプトがより簡潔になり、プロジェクト全体のビルド設定の一貫性が保たれます。
