### PR TITLE
refactor: Repository interfaces を domain module に移動

### DIFF
--- a/.serena/project.yml
+++ b/.serena/project.yml
@@ -110,3 +110,14 @@ default_modes:
 # initial prompt for the project. It will always be given to the LLM upon activating the project
 # (contrary to the memories, which are loaded on demand).
 initial_prompt: ""
+
+# override of the corresponding setting in serena_config.yml, see the documentation there.
+# If null or missing, the value from the global config is used.
+symbol_info_budget:
+
+# The language backend to use for this project.
+# If not set, the global setting from serena_config.yml is used.
+# Valid values: LSP, JetBrains
+# Note: the backend is fixed at startup. If a project with a different backend
+# is activated post-init, an error will be returned.
+language_backend:

--- a/androidApp/src/main/java/com/yaeyama/linerchecker/ui/dashboard/DashBoardViewModel.kt
+++ b/androidApp/src/main/java/com/yaeyama/linerchecker/ui/dashboard/DashBoardViewModel.kt
@@ -2,7 +2,7 @@ package com.yaeyama.linerchecker.ui.dashboard
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.yaeyama.linerchecker.repository.TopStatusRepository
+import com.yaeyama_liner_checker.domain.repository.TopStatusRepository
 import com.yaeyama_liner_checker.domain.top.Ports
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted

--- a/androidApp/src/main/java/com/yaeyama/linerchecker/ui/main/MainViewModel.kt
+++ b/androidApp/src/main/java/com/yaeyama/linerchecker/ui/main/MainViewModel.kt
@@ -1,7 +1,7 @@
 package com.yaeyama.linerchecker.ui.main
 
 import androidx.lifecycle.ViewModel
-import com.yaeyama.linerchecker.repository.TyphoonRepository
+import com.yaeyama_liner_checker.domain.repository.TyphoonRepository
 import com.yaeyama_liner_checker.domain.tyhoon.Typhoon
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map

--- a/androidApp/src/main/java/com/yaeyama/linerchecker/ui/portstatusdetail/PortStatusDetailViewModel.kt
+++ b/androidApp/src/main/java/com/yaeyama/linerchecker/ui/portstatusdetail/PortStatusDetailViewModel.kt
@@ -2,7 +2,7 @@ package com.yaeyama.linerchecker.ui.portstatusdetail
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.yaeyama.linerchecker.repository.StatusDetailRepository
+import com.yaeyama_liner_checker.domain.repository.StatusDetailRepository
 import com.yaeyama_liner_checker.domain.statusdetail.Company
 import com.yaeyama_liner_checker.domain.statusdetail.PortStatus
 import com.yaeyama_liner_checker.domain.time_table.TimeTable

--- a/androidApp/src/main/java/com/yaeyama/linerchecker/ui/typhoon/list/TyphoonListViewModel.kt
+++ b/androidApp/src/main/java/com/yaeyama/linerchecker/ui/typhoon/list/TyphoonListViewModel.kt
@@ -2,7 +2,7 @@ package com.yaeyama.linerchecker.ui.typhoon.list
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.yaeyama.linerchecker.repository.TyphoonRepository
+import com.yaeyama_liner_checker.domain.repository.TyphoonRepository
 import com.yaeyama_liner_checker.domain.tyhoon.Typhoon
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.SharingStarted.Companion.WhileSubscribed

--- a/androidApp/src/main/java/com/yaeyama/linerchecker/ui/weather/WeatherViewModel.kt
+++ b/androidApp/src/main/java/com/yaeyama/linerchecker/ui/weather/WeatherViewModel.kt
@@ -2,8 +2,8 @@ package com.yaeyama.linerchecker.ui.weather
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.yaeyama.linerchecker.repository.UiState
-import com.yaeyama.linerchecker.repository.WeatherRepository
+import com.yaeyama_liner_checker.domain.common.UiState
+import com.yaeyama_liner_checker.domain.repository.WeatherRepository
 import com.yaeyama_liner_checker.domain.weather.WeatherInfo
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow

--- a/data/src/debug/kotlin/com/yaeyama/linerchecker/di/DataModule.kt
+++ b/data/src/debug/kotlin/com/yaeyama/linerchecker/di/DataModule.kt
@@ -4,14 +4,14 @@ import com.google.firebase.database.FirebaseDatabase
 import com.google.firebase.database.ktx.database
 import com.google.firebase.ktx.Firebase
 import com.google.firebase.ktx.app
-import com.yaeyama.linerchecker.repository.StatusDetailRepository
 import com.yaeyama.linerchecker.repository.StatusDetailRepositoryImpl
-import com.yaeyama.linerchecker.repository.TopStatusRepository
 import com.yaeyama.linerchecker.repository.TopStatusRepositoryImpl
-import com.yaeyama.linerchecker.repository.TyphoonRepository
 import com.yaeyama.linerchecker.repository.TyphoonRepositoryImpl
-import com.yaeyama.linerchecker.repository.WeatherRepository
 import com.yaeyama.linerchecker.repository.WeatherRepositoryImpl
+import com.yaeyama_liner_checker.domain.repository.StatusDetailRepository
+import com.yaeyama_liner_checker.domain.repository.TopStatusRepository
+import com.yaeyama_liner_checker.domain.repository.TyphoonRepository
+import com.yaeyama_liner_checker.domain.repository.WeatherRepository
 import org.koin.dsl.module
 
 /**

--- a/data/src/debug/kotlin/com/yaeyama/linerchecker/repository/FakeStatusDetailRepository.kt
+++ b/data/src/debug/kotlin/com/yaeyama/linerchecker/repository/FakeStatusDetailRepository.kt
@@ -1,6 +1,7 @@
 package com.yaeyama.linerchecker.repository
 
 import android.util.Log
+import com.yaeyama_liner_checker.domain.repository.StatusDetailRepository
 import com.yaeyama_liner_checker.domain.statusdetail.Company
 import com.yaeyama_liner_checker.domain.statusdetail.PortStatus
 import com.yaeyama_liner_checker.domain.statusdetail.Status

--- a/data/src/debug/kotlin/com/yaeyama/linerchecker/repository/FakeTopStatusRepository.kt
+++ b/data/src/debug/kotlin/com/yaeyama/linerchecker/repository/FakeTopStatusRepository.kt
@@ -1,5 +1,6 @@
 package com.yaeyama.linerchecker.repository
 
+import com.yaeyama_liner_checker.domain.repository.TopStatusRepository
 import com.yaeyama_liner_checker.domain.statusdetail.PortStatus
 import com.yaeyama_liner_checker.domain.statusdetail.Status
 import com.yaeyama_liner_checker.domain.top.Ports

--- a/data/src/debug/kotlin/com/yaeyama/linerchecker/repository/FakeTyphoonRepositoryImpl.kt
+++ b/data/src/debug/kotlin/com/yaeyama/linerchecker/repository/FakeTyphoonRepositoryImpl.kt
@@ -1,5 +1,6 @@
 package com.yaeyama.linerchecker.repository
 
+import com.yaeyama_liner_checker.domain.repository.TyphoonRepository
 import com.yaeyama_liner_checker.domain.tyhoon.Typhoon
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow

--- a/data/src/main/kotlin/com/yaeyama/linerchecker/repository/DebugWeatherRepositoryImpl.kt
+++ b/data/src/main/kotlin/com/yaeyama/linerchecker/repository/DebugWeatherRepositoryImpl.kt
@@ -1,5 +1,7 @@
 package com.yaeyama.linerchecker.repository
 
+import com.yaeyama_liner_checker.domain.common.UiState
+import com.yaeyama_liner_checker.domain.repository.WeatherRepository
 import com.yaeyama_liner_checker.domain.weather.Table
 import com.yaeyama_liner_checker.domain.weather.Temperature
 import com.yaeyama_liner_checker.domain.weather.Weather

--- a/data/src/main/kotlin/com/yaeyama/linerchecker/repository/StatusDetailRepositoryImpl.kt
+++ b/data/src/main/kotlin/com/yaeyama/linerchecker/repository/StatusDetailRepositoryImpl.kt
@@ -5,6 +5,7 @@ import com.google.firebase.database.DatabaseError
 import com.google.firebase.database.FirebaseDatabase
 import com.google.firebase.database.ValueEventListener
 import com.google.firebase.database.ktx.getValue
+import com.yaeyama_liner_checker.domain.repository.StatusDetailRepository
 import com.yaeyama_liner_checker.domain.statusdetail.Company
 import com.yaeyama_liner_checker.domain.statusdetail.PortStatus
 import com.yaeyama_liner_checker.domain.time_table.TimeTable

--- a/data/src/main/kotlin/com/yaeyama/linerchecker/repository/TopStatusRepositoryImpl.kt
+++ b/data/src/main/kotlin/com/yaeyama/linerchecker/repository/TopStatusRepositoryImpl.kt
@@ -5,6 +5,7 @@ import com.google.firebase.database.FirebaseDatabase
 import com.google.firebase.database.ktx.getValue
 import com.yaeyama.linerchecker.ext.reference
 import com.yaeyama.linerchecker.ext.valueEvents
+import com.yaeyama_liner_checker.domain.repository.TopStatusRepository
 import com.yaeyama_liner_checker.domain.top.Ports
 import com.yaeyama_liner_checker.domain.top.TopPort
 import kotlinx.coroutines.flow.Flow

--- a/data/src/main/kotlin/com/yaeyama/linerchecker/repository/TyphoonRepositoryImpl.kt
+++ b/data/src/main/kotlin/com/yaeyama/linerchecker/repository/TyphoonRepositoryImpl.kt
@@ -5,6 +5,7 @@ import com.google.firebase.database.FirebaseDatabase
 import com.google.firebase.database.ktx.getValue
 import com.yaeyama.linerchecker.ext.reference
 import com.yaeyama.linerchecker.ext.valueEvents
+import com.yaeyama_liner_checker.domain.repository.TyphoonRepository
 import com.yaeyama_liner_checker.domain.tyhoon.Typhoon
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.catch

--- a/data/src/main/kotlin/com/yaeyama/linerchecker/repository/WeatherRepositoryImpl.kt
+++ b/data/src/main/kotlin/com/yaeyama/linerchecker/repository/WeatherRepositoryImpl.kt
@@ -5,6 +5,8 @@ import com.google.firebase.database.FirebaseDatabase
 import com.google.firebase.database.ktx.getValue
 import com.yaeyama.linerchecker.ext.reference
 import com.yaeyama.linerchecker.ext.valueEvents
+import com.yaeyama_liner_checker.domain.common.UiState
+import com.yaeyama_liner_checker.domain.repository.WeatherRepository
 import com.yaeyama_liner_checker.domain.weather.WeatherInfo
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.catch

--- a/data/src/main/kotlin/com/yaeyama/linerchecker/usecase/GetStatusDetail.kt
+++ b/data/src/main/kotlin/com/yaeyama/linerchecker/usecase/GetStatusDetail.kt
@@ -1,7 +1,6 @@
 package com.yaeyama.linerchecker.usecase
 
-import com.yaeyama.linerchecker.repository.StatusDetailRepository
-import com.yaeyama.linerchecker.repository.UiState
+import com.yaeyama_liner_checker.domain.repository.StatusDetailRepository
 import com.yaeyama_liner_checker.domain.statusdetail.Company
 import com.yaeyama_liner_checker.domain.statusdetail.PortStatus
 import com.yaeyama_liner_checker.domain.statusdetail.StatusDetailResult

--- a/data/src/release/kotlin/com/yaeyama/linerchecker/di/DataModule.kt
+++ b/data/src/release/kotlin/com/yaeyama/linerchecker/di/DataModule.kt
@@ -4,14 +4,14 @@ import com.google.firebase.database.FirebaseDatabase
 import com.google.firebase.database.ktx.database
 import com.google.firebase.ktx.Firebase
 import com.google.firebase.ktx.app
-import com.yaeyama.linerchecker.repository.StatusDetailRepository
 import com.yaeyama.linerchecker.repository.StatusDetailRepositoryImpl
-import com.yaeyama.linerchecker.repository.TopStatusRepository
 import com.yaeyama.linerchecker.repository.TopStatusRepositoryImpl
-import com.yaeyama.linerchecker.repository.TyphoonRepository
 import com.yaeyama.linerchecker.repository.TyphoonRepositoryImpl
-import com.yaeyama.linerchecker.repository.WeatherRepository
 import com.yaeyama.linerchecker.repository.WeatherRepositoryImpl
+import com.yaeyama_liner_checker.domain.repository.StatusDetailRepository
+import com.yaeyama_liner_checker.domain.repository.TopStatusRepository
+import com.yaeyama_liner_checker.domain.repository.TyphoonRepository
+import com.yaeyama_liner_checker.domain.repository.WeatherRepository
 import org.koin.dsl.module
 
 /**

--- a/domain/build.gradle.kts
+++ b/domain/build.gradle.kts
@@ -1,3 +1,7 @@
 plugins {
     id("yaeyama.kotlin.library")
 }
+
+dependencies {
+    implementation(libs.coroutines.core)
+}

--- a/domain/src/main/java/com/yaeyama_liner_checker/domain/common/UiState.kt
+++ b/domain/src/main/java/com/yaeyama_liner_checker/domain/common/UiState.kt
@@ -1,4 +1,4 @@
-package com.yaeyama.linerchecker.repository
+package com.yaeyama_liner_checker.domain.common
 
 sealed class UiState<out T> {
     object Loading

--- a/domain/src/main/java/com/yaeyama_liner_checker/domain/repository/StatusDetailRepository.kt
+++ b/domain/src/main/java/com/yaeyama_liner_checker/domain/repository/StatusDetailRepository.kt
@@ -1,4 +1,4 @@
-package com.yaeyama.linerchecker.repository
+package com.yaeyama_liner_checker.domain.repository
 
 import com.yaeyama_liner_checker.domain.statusdetail.Company
 import com.yaeyama_liner_checker.domain.statusdetail.PortStatus

--- a/domain/src/main/java/com/yaeyama_liner_checker/domain/repository/TopStatusRepository.kt
+++ b/domain/src/main/java/com/yaeyama_liner_checker/domain/repository/TopStatusRepository.kt
@@ -1,4 +1,4 @@
-package com.yaeyama.linerchecker.repository
+package com.yaeyama_liner_checker.domain.repository
 
 import com.yaeyama_liner_checker.domain.top.Ports
 import kotlinx.coroutines.flow.Flow

--- a/domain/src/main/java/com/yaeyama_liner_checker/domain/repository/TyphoonRepository.kt
+++ b/domain/src/main/java/com/yaeyama_liner_checker/domain/repository/TyphoonRepository.kt
@@ -1,4 +1,4 @@
-package com.yaeyama.linerchecker.repository
+package com.yaeyama_liner_checker.domain.repository
 
 import com.yaeyama_liner_checker.domain.tyhoon.Typhoon
 import kotlinx.coroutines.flow.Flow

--- a/domain/src/main/java/com/yaeyama_liner_checker/domain/repository/WeatherRepository.kt
+++ b/domain/src/main/java/com/yaeyama_liner_checker/domain/repository/WeatherRepository.kt
@@ -1,5 +1,6 @@
-package com.yaeyama.linerchecker.repository
+package com.yaeyama_liner_checker.domain.repository
 
+import com.yaeyama_liner_checker.domain.common.UiState
 import com.yaeyama_liner_checker.domain.weather.WeatherInfo
 import kotlinx.coroutines.flow.Flow
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -93,6 +93,7 @@ firebase-database = {group = "com.google.firebase", name = "firebase-database-kt
 firebase-analytics = {group = "com.google.firebase", name = "firebase-analytics-ktx"}
 firebase-crashlytics = {group = "com.google.firebase", name = "firebase-crashlytics"}
 coroutines-android = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-android", version.ref = "kotlinxCoroutinesAndroid" }
+coroutines-core = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref = "kotlinxCoroutinesAndroid" }
 google-services = { module = "com.google.gms:google-services", version.ref = "googleServices" }
 gradle = { module = "com.android.tools.build:gradle", version.ref = "androidGradlePlugin" }
 timber = { module = "com.jakewharton.timber:timber", version.ref = "timber" }


### PR DESCRIPTION
## 何を変更しましたか？

<!-- 変更内容を簡潔に記述してください。 -->
- Repository インターフェースをdomainモジュールへ移動
- Repository実装クラスはdataのまま

## なぜ変更しましたか？

<!-- 変更の目的や背景を説明してください。 -->
`domain` と `data` の責務が逆転していた

## 関連するIssue

<!--関連するIssue番号があれば記載してください、なければ空欄でOKです。 -->

## 影響範囲

<!-- 変更が及ぶ可能性のある範囲を記述してください。 -->
アプリ全体

## スクリーンショット
UIに影響なし

