### PR TITLE
refactor: ダッシュボードViewModelの状態結合とトップステータス取得を修正

### DIFF
--- a/.serena/project.yml
+++ b/.serena/project.yml
@@ -130,3 +130,17 @@ read_only_memory_patterns: []
 # Possible values: unset (use global setting), "lf", "crlf", or "native" (platform default)
 # This does not affect Serena's own files (e.g. memories and configuration files), which always use native line endings.
 line_ending:
+
+# list of regex patterns for memories to completely ignore.
+# Matching memories will not appear in list_memories or activate_project output
+# and cannot be accessed via read_memory or write_memory.
+# To access ignored memory files, use the read_file tool on the raw file path.
+# Extends the list from the global configuration, merging the two lists.
+# Example: ["_archive/.*", "_episodes/.*"]
+ignored_memory_patterns: []
+
+# advanced configuration option allowing to configure language server-specific options.
+# Maps the language key to the options.
+# Have a look at the docstring of the constructors of the LS implementations within solidlsp (e.g., for C# or PHP) to see which options are available.
+# No documentation on options means no options are available.
+ls_specific_settings: {}

--- a/androidApp/src/main/java/com/yaeyama/linerchecker/ui/dashboard/DashBoardViewModel.kt
+++ b/androidApp/src/main/java/com/yaeyama/linerchecker/ui/dashboard/DashBoardViewModel.kt
@@ -4,14 +4,18 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.yaeyama_liner_checker.domain.repository.TopStatusRepository
 import com.yaeyama_liner_checker.domain.top.Ports
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.combine
-import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.flow.onStart
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
+import timber.log.Timber
 
 /**
  * トップに表示するステータスのダッシュボード ViewModel
@@ -24,15 +28,17 @@ class DashBoardViewModel(
     private val isError = MutableStateFlow(false)
     private val portList: MutableStateFlow<List<Ports>> = MutableStateFlow(listOf())
 
+    private var topStatusesJob: Job? = null
+
     val uiState: StateFlow<DashBoardUiState> = combine(
         isLoading,
         isError,
         portList,
-    ) { isError, isLoading, portList ->
+    ) { loading, error, ports ->
         DashBoardUiState(
-            isLoading = isLoading,
-            isError = isError,
-            portList = portList,
+            isLoading = loading,
+            isError = error,
+            portList = ports,
         )
     }.stateIn(
         scope = viewModelScope,
@@ -40,16 +46,19 @@ class DashBoardViewModel(
         initialValue = DashBoardUiState.InitialValue,
     )
 
-    suspend fun fetchPortList() {
-        viewModelScope.launch {
-            runCatching {
-                portList.update {
-                    topStatusRepository.fetchTopStatuses().first()
+    fun fetchPortList() {
+        topStatusesJob?.cancel()
+        topStatusesJob = viewModelScope.launch {
+            isError.update { false }
+            topStatusRepository.fetchTopStatuses()
+                .onStart { isLoading.update { true } }
+                .onEach { isLoading.update { false } }
+                .catch { e ->
+                    Timber.e(e, "fetchTopStatuses failed")
+                    isLoading.update { false }
+                    isError.update { true }
                 }
-            }.onFailure {
-                isLoading.update { false }
-                isError.update { true }
-            }
+                .collect { portList.value = it }
         }
     }
 }

--- a/androidApp/src/main/java/com/yaeyama/linerchecker/ui/portstatusdetail/PortStatusDetailViewModel.kt
+++ b/androidApp/src/main/java/com/yaeyama/linerchecker/ui/portstatusdetail/PortStatusDetailViewModel.kt
@@ -6,15 +6,16 @@ import com.yaeyama_liner_checker.domain.repository.StatusDetailRepository
 import com.yaeyama_liner_checker.domain.statusdetail.Company
 import com.yaeyama_liner_checker.domain.statusdetail.PortStatus
 import com.yaeyama_liner_checker.domain.time_table.TimeTable
-import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.combine
-import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
+import timber.log.Timber
 
 /**
  * 運行詳細 ViewModel
@@ -27,6 +28,9 @@ class PortStatusDetailViewModel(
     private val isError = MutableStateFlow(false)
     private val portStatus = MutableStateFlow(PortStatus())
     private val timeTable = MutableStateFlow(TimeTable())
+
+    private var statusDetailJob: Job? = null
+    private var timeTableJob: Job? = null
 
     val uiState: StateFlow<PortStatusDetailUiState> = combine(
         isLoading,
@@ -55,23 +59,27 @@ class PortStatusDetailViewModel(
         company: Company,
         portCode: String,
     ) {
-        viewModelScope.launch {
-            runCatching {
-                val res: Flow<PortStatus> = statusDetailRepository.fetchStatusDetail(company = company, portCode = portCode)
-                portStatus.update { res.first() } // TODO: firstをやめたい
-            }.onFailure {
-                isError.update { true }
-            }
+        statusDetailJob?.cancel()
+        timeTableJob?.cancel()
+        isError.update { false }
 
-        }
-        viewModelScope.launch {
-            runCatching {
-                timeTable.update {
-                    statusDetailRepository.fetchTimeTable(company, portCode).first()  // TODO: firstをやめたい
+        statusDetailJob = viewModelScope.launch {
+            statusDetailRepository.fetchStatusDetail(company = company, portCode = portCode)
+                .catch { e ->
+                    Timber.e(e, "fetchStatusDetail failed")
+                    isError.update { true }
                 }
-            }.onFailure {
-                isError.update { true } // TODO: TimeTableだけエラーの場合を考慮する
-            }
+                .collect { portStatus.value = it }
+        }
+
+        timeTableJob = viewModelScope.launch {
+            statusDetailRepository.fetchTimeTable(company, portCode)
+                .catch { e ->
+                    Timber.e(e, "fetchTimeTable failed")
+                    // TODO: 時刻表のみ失敗した場合は isError を分離して扱う
+                    isError.update { true }
+                }
+                .collect { timeTable.value = it }
         }
     }
 }


### PR DESCRIPTION
## 何を変更しましたか？

- ダッシュボード／港別詳細のViewModelでcombine不具合を修正しFlowをcollect化
- Serenaの`project.yml`を更新

## なぜ変更しましたか？

- ダッシュボードでは `isLoading` / `isError` が実際の状態と逆に見える表示不具合があったため、正しい対応関係に直す必要があった。
- トップステータス・港別詳細とも、Firebase 等からの更新を `Flow` で受け取る設計に合わせ、`first()` で最初の1件だけ取ると後続の更新が画面に反映されない。また画面を再度開いたときに古い `launch` が残る可能性があったため、キャンセルと `collect` による継続購読に寄せた。
- Serena の設定はツール側の新オプションに追随するためのメンテナンスである。

## どのように変更しましたか？

- **ダッシュボード**: `combine(isLoading, isError, portList) { loading, error, ports -> ... }` とし、`fetchPortList` 内で `topStatusesJob` を保持して再呼び出し時に `cancel`。`onStart` / `onEach` でローディング、`catch` で `Timber` ログと `isError`、成功時は `collect` で `portList` を更新。
- **港別詳細**: `statusDetailJob` / `timeTableJob` を分けてキャンセル可能にし、`fetchStatusDetail` / `fetchTimeTable` それぞれを `catch` + `collect` で購読。失敗時は `Timber` と `isError`。時刻表のみ失敗した場合の `isError` 分離は TODO のまま残している。
- **Serena**: `project.yml` にドキュメント記載の設定ブロックを追加。

## 関連するIssue

（なし）

## 影響範囲

- **ユーザー向け**: ダッシュボードの読み込み・エラー表示の正しさ、トップ・港別詳細でのデータ更新の追従（再入時のジョブ整理を含む）。
- **コード**: `androidApp` の上記2 ViewModel、`.serena/project.yml`（エディタ／MCP 利用者向けのみ）。

## スクリーンショット

UI の見た目のデザイン変更はないが、ダッシュボードで誤って表示されていたローディング／エラー表示が正しくなる。



## 備考

- 港別詳細では、時刻表取得のみ失敗した場合に運行詳細とエラー表示を分けたい旨の TODO がコメントで残っている。
- マージ前に実機またはエミュレータでダッシュボード再表示・港別詳細の再入を確認すると安心である。
